### PR TITLE
Feature/get or create

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ if ($mutex->lock()) {
 
 ### Helpers
 
-**Get-Or-Create** provides a simple way to attempt retrieval of a resource,
+**Get-Or-Create** provides a simple way to attempt retrieval of a value,
 or create it using a mutex if it doesn't already exist
 
 ```php

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ $ composer require phlib/mutex
 
 ## Usage
 
+### MySQL
+
 ```php
 $mutex = new \Phlib\Mutex\MySQL([
     'host'     => '127.0.0.1',
@@ -26,4 +28,26 @@ $mutex = new \Phlib\Mutex\MySQL([
 $mutex->acquire('my-lock');
 // Do some data manipulation while locked
 $mutex->release('my-lock');
+```
+
+### Helpers
+
+**Get-Or-Create** provides a simple way to attempt retrieval of a resource,
+or create it using a mutex if it doesn't already exist
+
+```php
+$getClosure = function() {
+    // attempt to get a value, eg. from DB, cache, etc.
+    if (!$value) {
+        throw new \Phlib\Mutex\NotFoundException();
+    }
+    return $value;
+};
+
+$createClosure = function() {
+    // attempt to create a value and write eg. to DB, cache, etc.
+    return $value;
+};
+
+$value = \Phlib\Mutex\Helper::getOrCreate($mutex, $getClosure, $createClosure);
 ```

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Phlib\Mutex;
+
+/**
+ * Mutex helper functions
+ *
+ * @package Phlib\Mutex
+ */
+class Helper
+{
+    /**
+     * Tries to get a resource (e.g. a row from the database) using the getClosure, and if it does not
+     * exist, calls the createClosure to create the resource and return it
+     *
+     * The getClosure should return the resource, or throw a NotFoundException
+     * The createClosure should create the resource and return the created resource
+     *
+     * @param MutexInterface $mutex
+     * @param \Closure $getClosure
+     * @param \Closure $createClosure
+     * @param int $wait Number of seconds to wait for lock
+     * @return mixed
+     */
+    public static function getOrCreate(MutexInterface $mutex, \Closure $getClosure, \Closure $createClosure, $wait = 0)
+    {
+        try {
+            $value = $getClosure();
+        } catch (NotFoundException $e) {
+
+            $mutex->lock($wait);
+
+            try {
+                $value = $getClosure();
+            } catch (NotFoundException $e) {
+                $value = $createClosure();
+            }
+
+            $mutex->unlock();
+        }
+
+        return $value;
+    }
+}

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -10,11 +10,11 @@ namespace Phlib\Mutex;
 class Helper
 {
     /**
-     * Tries to get a resource (e.g. a row from the database) using the getClosure, and if it does not
-     * exist, calls the createClosure to create the resource and return it
+     * Tries to get a value (eg. from a database) using the getClosure, and if it does not
+     * exist, uses the mutex while calling the createClosure to create the value and return it
      *
-     * The getClosure should return the resource, or throw a NotFoundException
-     * The createClosure should create the resource and return the created resource
+     * The getClosure should return the value, or throw a NotFoundException
+     * The createClosure should create the value and return the created value
      *
      * @param MutexInterface $mutex
      * @param \Closure $getClosure

--- a/src/NotFoundException.php
+++ b/src/NotFoundException.php
@@ -3,7 +3,7 @@
 namespace Phlib\Mutex;
 
 /**
- * Exception used to represent a resource not found
+ * Exception used to represent a value not found
  *
  * @package Phlib\Mutex
  * @see Phlib\Mutex\Mutex::getorCreate()

--- a/src/NotFoundException.php
+++ b/src/NotFoundException.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Phlib\Mutex;
+
+/**
+ * Exception used to represent a resource not found
+ *
+ * @package Phlib\Mutex
+ * @see Phlib\Mutex\Mutex::getorCreate()
+ * @extends \RuntimeException
+ */
+class NotFoundException extends \RuntimeException
+{
+    // void
+}

--- a/tests/HelperTest.php
+++ b/tests/HelperTest.php
@@ -1,0 +1,233 @@
+<?php
+
+namespace Phlib\Mutex\Test;
+
+use Phlib\Mutex\Helper;
+use Phlib\Mutex\MutexInterface;
+use Phlib\Mutex\NotFoundException;
+
+class HelperTest extends \PHPUnit_Framework_TestCase
+{
+    const LOCK_NAME = 'dummyLock';
+
+    /**
+     * @var MutexInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $mutex;
+
+    protected function setUp()
+    {
+        // Mock Mutex
+        $this->mutex = $this->getMockBuilder('\Phlib\Mutex\MutexInterface')
+            ->getMock();
+    }
+
+    public function testGetOrCreateGetValid()
+    {
+        $expected = 'valid';
+
+        $getClosure = function() use ($expected) {
+            return $expected;
+        };
+        $createClosure = function() {
+            $this->fail('Create Closure was not expected to be called');
+        };
+
+        $result = Helper::getOrCreate($this->mutex, $getClosure, $createClosure);
+
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage Get exception
+     */
+    public function testGetOrCreateGetException()
+    {
+        $getClosure = function() {
+            throw new \Exception('Get exception');
+        };
+        $createClosure = function() {
+            $this->fail('Create Closure was not expected to be called');
+        };
+
+        Helper::getOrCreate($this->mutex, $getClosure, $createClosure);
+    }
+
+    public function testGetOrCreateGetFailThenValid()
+    {
+        $expected = 'valid';
+
+        $count = 0;
+        $getClosure = function() use ($expected, &$count) {
+            switch (++$count) {
+                case 1 :
+                    return $expected;
+                case 2 :
+                    throw new NotFoundException('Value not found');
+                default :
+                    $this->fail('Get Closure was not expected to be called more than twice');
+                    return null;
+                    break;
+            }
+        };
+        $createClosure = function() {
+            $this->fail('Create Closure was not expected to be called');
+        };
+
+        $result = Helper::getOrCreate($this->mutex, $getClosure, $createClosure);
+
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage Get exception
+     */
+    public function testGetOrCreateGetFailThenException()
+    {
+        $count = 0;
+        $getClosure = function() use (&$count) {
+            switch (++$count) {
+                case 1 :
+                    throw new NotFoundException('Value not found');
+                case 2 :
+                    throw new \Exception('Get exception');
+                default :
+                    $this->fail('Get Closure was not expected to be called more than twice');
+                    return null;
+                    break;
+            }
+        };
+        $createClosure = function() {
+            $this->fail('Create Closure was not expected to be called');
+        };
+
+        Helper::getOrCreate($this->mutex, $getClosure, $createClosure);
+    }
+
+    public function testGetOrCreateGetFailThenCreate()
+    {
+        $expected = 'valid';
+
+        $count = 0;
+        $getClosure = function() use (&$count) {
+            switch (++$count) {
+                case 1 :
+                    // no break
+                case 2 :
+                    throw new NotFoundException('Value not found');
+                default :
+                    $this->fail('Get Closure was not expected to be called more than twice');
+                    return null;
+                    break;
+            }
+        };
+        $createClosure = function() use ($expected) {
+            $this->mutex->expects($this->at(1))
+                ->method('unlock');
+            ;
+            return $expected;
+        };
+
+        $this->mutex->expects($this->at(0))
+            ->method('lock')
+            ->with(0) // Default value
+        ;
+        $this->mutex->expects($this->at(1))
+            ->method('unlock')
+            ->will($this->throwException(new \PHPUnit_Framework_AssertionFailedError('Unlock should not be called')));
+        ;
+
+        $result = Helper::getOrCreate($this->mutex, $getClosure, $createClosure);
+
+        $this->assertEquals($expected, $result);
+    }
+
+    public function testGetOrCreateGetFailThenCreateWait()
+    {
+        $expected = 'valid';
+
+        $count = 0;
+        $getClosure = function() use (&$count) {
+            switch (++$count) {
+                case 1 :
+                    // no break
+                case 2 :
+                    throw new NotFoundException('Value not found');
+                default :
+                    $this->fail('Get Closure was not expected to be called more than twice');
+                    return null;
+                    break;
+            }
+        };
+        $createClosure = function() use ($expected) {
+            return $expected;
+        };
+
+        $wait = 10;
+        $this->mutex->expects($this->at(0))
+            ->method('lock')
+            ->with($wait)
+        ;
+        $this->mutex->expects($this->at(1))
+            ->method('unlock')
+        ;
+
+        $result = Helper::getOrCreate($this->mutex, $getClosure, $createClosure, $wait);
+
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage Create exception
+     */
+    public function testGetOrCreateGetFailThenCreateException()
+    {
+        $count = 0;
+        $getClosure = function() use (&$count) {
+            switch (++$count) {
+                case 1 :
+                    // no break
+                case 2 :
+                    throw new NotFoundException('Value not found');
+                default :
+                    $this->fail('Get Closure was not expected to be called more than twice');
+                    return null;
+                    break;
+            }
+        };
+        $createClosure = function() {
+            throw new \Exception('Create exception');
+        };
+
+        Helper::getOrCreate($this->mutex, $getClosure, $createClosure);
+    }
+
+    /**
+     * @expectedException \Phlib\Mutex\NotFoundException
+     * @expectedExceptionMessage Create not found exception
+     */
+    public function testGetOrCreateGetFailThenCreateNotFoundException()
+    {
+        $count = 0;
+        $getClosure = function() use (&$count) {
+            switch (++$count) {
+                case 1 :
+                    // no break
+                case 2 :
+                    throw new NotFoundException('Value not found');
+                default :
+                    $this->fail('Get Closure was not expected to be called more than twice');
+                    return null;
+                    break;
+            }
+        };
+        $createClosure = function() {
+            throw new NotFoundException('Create not found exception');
+        };
+
+        Helper::getOrCreate($this->mutex, $getClosure, $createClosure);
+    }
+}

--- a/tests/HelperTest.php
+++ b/tests/HelperTest.php
@@ -62,9 +62,9 @@ class HelperTest extends \PHPUnit_Framework_TestCase
         $getClosure = function() use ($expected, &$count) {
             switch (++$count) {
                 case 1 :
-                    return $expected;
-                case 2 :
                     throw new NotFoundException('Value not found');
+                case 2 :
+                    return $expected;
                 default :
                     $this->fail('Get Closure was not expected to be called more than twice');
                     return null;
@@ -74,6 +74,16 @@ class HelperTest extends \PHPUnit_Framework_TestCase
         $createClosure = function() {
             $this->fail('Create Closure was not expected to be called');
         };
+
+        $this->mutex->expects($this->at(0))
+            ->method('lock')
+            ->with(0) // Default value
+            ->will($this->returnValue(true))
+        ;
+        $this->mutex->expects($this->at(1))
+            ->method('unlock')
+            ->will($this->returnValue(true))
+        ;
 
         $result = Helper::getOrCreate($this->mutex, $getClosure, $createClosure);
 

--- a/tests/HelperTest.php
+++ b/tests/HelperTest.php
@@ -124,9 +124,6 @@ class HelperTest extends \PHPUnit_Framework_TestCase
             }
         };
         $createClosure = function() use ($expected) {
-            $this->mutex->expects($this->at(1))
-                ->method('unlock');
-            ;
             return $expected;
         };
 
@@ -136,7 +133,6 @@ class HelperTest extends \PHPUnit_Framework_TestCase
         ;
         $this->mutex->expects($this->at(1))
             ->method('unlock')
-            ->will($this->throwException(new \PHPUnit_Framework_AssertionFailedError('Unlock should not be called')));
         ;
 
         $result = Helper::getOrCreate($this->mutex, $getClosure, $createClosure);


### PR DESCRIPTION
Add GetOrCreate helper method.

Statically accessed for ease-of-use, the method requires a `MutexInterface` as well as get and create closures to fetch a value, mutex locking when the value isn't found and needs to be created.

A new exception class is used to allow the _get_ closure to clearly indicate when the value cannot be found.
