### PR TITLE
PHP v8.0

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -12,6 +12,7 @@ jobs:
       matrix:
         php:
           - '7.4'
+          - '8.0'
 
     name: PHP ${{ matrix.php }} tests
 

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -11,7 +11,6 @@ jobs:
     strategy:
       matrix:
         php:
-          - '7.0'
           - '7.1'
           - '7.2'
           - '7.3'

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -11,16 +11,13 @@ jobs:
     strategy:
       matrix:
         php:
-          - '7.1'
-          - '7.2'
-          - '7.3'
           - '7.4'
 
     name: PHP ${{ matrix.php }} tests
 
     services:
       mysql:
-        image: mysql:5.7
+        image: mysql:latest
         env:
           MYSQL_DATABASE: test_database
           MYSQL_HOST: 127.0.0.1

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-
-composer.lock
-/vendor/
+/vendor
+/composer.lock
+/.phpunit.result.cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Type declarations have been added to all method parameters and return types
   where possible.
+### Changed
+- **BC break**: Reduce visibility of internal methods and properties. These
+  members are not part of the public API. No impact to standard use of this
+  package. If an implementation has a use case which needs to override these
+  members, please submit a pull request explaining the change.
 ### Removed
 - **BC break**: Removed support for PHP v7.0 as it is no longer
   [actively supported](https://php.net/supported-versions.php) by the PHP project.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Type declarations have been added to all method parameters and return types
+  where possible.
 ### Removed
 - **BC break**: Removed support for PHP v7.0 as it is no longer
   [actively supported](https://php.net/supported-versions.php) by the PHP project.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Removed
+- **BC break**: Removed support for PHP v7.0 as it is no longer
+  [actively supported](https://php.net/supported-versions.php) by the PHP project.
 
 ## [2.0.0] - 2018-02-28
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added
+- Add support for PHP v8.0 .
 - Type declarations have been added to all method parameters and return types
   where possible.
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   package. If an implementation has a use case which needs to override these
   members, please submit a pull request explaining the change.
 ### Removed
-- **BC break**: Removed support for PHP v7.0 as it is no longer
+- **BC break**: Removed support for PHP versions <= v7.3 as they are no longer
   [actively supported](https://php.net/supported-versions.php) by the PHP project.
 
 ## [2.0.0] - 2018-02-28

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "require-dev": {
         "ext-pdo": "*",
         "ext-pdo_mysql": "*",
-        "phpunit/phpunit" : "^8",
+        "phpunit/phpunit" : "^9",
         "symplify/easy-coding-standard": "^9"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
     "require-dev": {
         "ext-pdo": "*",
         "ext-pdo_mysql": "*",
-        "phpunit/phpunit" : "^7"
+        "phpunit/phpunit" : "^7",
+        "symplify/easy-coding-standard": "^9"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "require-dev": {
         "ext-pdo": "*",
         "ext-pdo_mysql": "*",
-        "phpunit/phpunit" : "^7",
+        "phpunit/phpunit" : "^8",
         "symplify/easy-coding-standard": "^9"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php" : "^7.1",
+        "php" : "^7.4",
         "phlib/config" : "^2"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "require-dev": {
         "ext-pdo": "*",
         "ext-pdo_mysql": "*",
-        "phpunit/phpunit" : "^6"
+        "phpunit/phpunit" : "^7"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php" : "^7.4",
+        "php" : "^7.4 || ^8.0",
         "phlib/config" : "^2"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php" : "^7",
+        "php" : "^7.1",
         "phlib/config" : "^2"
     },
     "suggest": {

--- a/ecs.php
+++ b/ecs.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symplify\EasyCodingStandard\ValueObject\Option;
+use Symplify\EasyCodingStandard\ValueObject\Set\SetList;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $parameters = $containerConfigurator->parameters();
+    $parameters->set(Option::PATHS, [
+        __DIR__ . '/src',
+        __DIR__ . '/tests',
+    ]);
+
+    $services = $containerConfigurator->services();
+
+    $containerConfigurator->import(SetList::COMMON);
+    // Remove sniff, from common/control-structures
+    $services->remove(\PhpCsFixer\Fixer\ClassNotation\OrderedClassElementsFixer::class);
+    // Remove sniff, from common/spaces
+    $services->remove(\PhpCsFixer\Fixer\Operator\NotOperatorWithSuccessorSpaceFixer::class);
+    $services->remove(\PhpCsFixer\Fixer\CastNotation\CastSpacesFixer::class);
+
+    // Save strict to later
+    $services->remove(\PhpCsFixer\Fixer\Strict\DeclareStrictTypesFixer::class);
+    $services->remove(\PhpCsFixer\Fixer\Strict\StrictParamFixer::class);
+    $services->remove(\PhpCsFixer\Fixer\Strict\StrictComparisonFixer::class);
+    $services->remove(\PhpCsFixer\Fixer\PhpUnit\PhpUnitStrictFixer::class);
+    $services->remove(\PhpCsFixer\Fixer\PhpUnit\PhpUnitSetUpTearDownVisibilityFixer::class);
+
+    $containerConfigurator->import(SetList::PSR_12);
+};

--- a/ecs.php
+++ b/ecs.php
@@ -22,12 +22,5 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->remove(\PhpCsFixer\Fixer\Operator\NotOperatorWithSuccessorSpaceFixer::class);
     $services->remove(\PhpCsFixer\Fixer\CastNotation\CastSpacesFixer::class);
 
-    // Save strict to later
-    $services->remove(\PhpCsFixer\Fixer\Strict\DeclareStrictTypesFixer::class);
-    $services->remove(\PhpCsFixer\Fixer\Strict\StrictParamFixer::class);
-    $services->remove(\PhpCsFixer\Fixer\Strict\StrictComparisonFixer::class);
-    $services->remove(\PhpCsFixer\Fixer\PhpUnit\PhpUnitStrictFixer::class);
-    $services->remove(\PhpCsFixer\Fixer\PhpUnit\PhpUnitSetUpTearDownVisibilityFixer::class);
-
     $containerConfigurator->import(SetList::PSR_12);
 };

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit bootstrap="vendor/autoload.php" colors="true">
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+    bootstrap="vendor/autoload.php"
+    beStrictAboutOutputDuringTests="true"
+    colors="true"
+>
     <php>
         <env name="INTEGRATION_ENABLED" value="0" />
         <env name="INTEGRATION_DB_HOST" value="127.0.0.1" />
@@ -10,13 +15,13 @@
         <env name="INTEGRATION_DB_SCHEMA" value="test" />
     </php>
     <testsuites>
-        <testsuite name="String Test Suite">
+        <testsuite name="Phlib Test Suite">
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
+    <coverage>
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+    </coverage>
 </phpunit>

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -16,9 +16,6 @@ class Helper
      * The getClosure should return the value, or throw a NotFoundException
      * The createClosure should create the value and return the created value
      *
-     * @param MutexInterface $mutex
-     * @param \Closure $getClosure
-     * @param \Closure $createClosure
      * @param int $wait Number of seconds to wait for lock
      * @return mixed Value from get or create closures
      */
@@ -27,7 +24,6 @@ class Helper
         try {
             $value = $getClosure();
         } catch (NotFoundException $e) {
-
             if ($mutex->lock($wait) === false) {
                 throw new \RuntimeException('Unable to acquire lock on mutex');
             }

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Mutex;
 
 /**

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -19,8 +19,12 @@ class Helper
      * @param int $wait Number of seconds to wait for lock
      * @return mixed Value from get or create closures
      */
-    public static function getOrCreate(MutexInterface $mutex, \Closure $getClosure, \Closure $createClosure, $wait = 0)
-    {
+    public static function getOrCreate(
+        MutexInterface $mutex,
+        \Closure $getClosure,
+        \Closure $createClosure,
+        int $wait = 0
+    ) {
         try {
             $value = $getClosure();
         } catch (NotFoundException $e) {

--- a/src/MutexInterface.php
+++ b/src/MutexInterface.php
@@ -10,17 +10,9 @@ namespace Phlib\Mutex;
 interface MutexInterface
 {
     /**
-     * Lock
-     *
      * @param int $wait Number of seconds to wait for lock
-     * @return bool
      */
-    public function lock($wait = 0);
+    public function lock(int $wait = 0): bool;
 
-    /**
-     * Unlock
-     *
-     * @return bool
-     */
-    public function unlock();
+    public function unlock(): bool;
 }

--- a/src/MutexInterface.php
+++ b/src/MutexInterface.php
@@ -9,7 +9,6 @@ namespace Phlib\Mutex;
  */
 interface MutexInterface
 {
-
     /**
      * Lock
      *

--- a/src/MutexInterface.php
+++ b/src/MutexInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Mutex;
 
 /**

--- a/src/MySQL.php
+++ b/src/MySQL.php
@@ -14,32 +14,32 @@ class MySQL implements MutexInterface
     /**
      * @var array
      */
-    protected $dbConfig;
+    private $dbConfig;
 
     /**
      * @var string
      */
-    protected $name;
+    private $name;
 
     /**
      * @var \PDO
      */
-    protected $connection;
+    private $connection;
 
     /**
      * @var \PDOStatement
      */
-    protected $stmtGetLock;
+    private $stmtGetLock;
 
     /**
      * @var \PDOStatement
      */
-    protected $stmtReleaseLock;
+    private $stmtReleaseLock;
 
     /**
      * @var bool
      */
-    protected $isLocked = false;
+    private $isLocked = false;
 
     /**
      * @param array $dbConfig {
@@ -104,6 +104,9 @@ class MySQL implements MutexInterface
 
     /**
      * Get connection, create if required
+     *
+     * Visibility `protected` so PDO dependency can be mocked in unit tests.
+     * @todo Refactor for proper dependency injection.
      */
     protected function getConnection(): \PDO
     {

--- a/src/MySQL.php
+++ b/src/MySQL.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Mutex;
 
 /**
@@ -72,10 +74,10 @@ class MySQL implements MutexInterface
         $result = $this->stmtGetLock->fetchColumn();
 
         if (is_numeric($result)) {
-            if ($result == 1) {
+            if ((int)$result === 1) {
                 $this->isLocked = true;
                 return true;
-            } elseif ($result == 0) {
+            } elseif ((int)$result === 0) {
                 return false;
             }
         }
@@ -94,7 +96,7 @@ class MySQL implements MutexInterface
             $this->isLocked = false;
             $this->stmtReleaseLock->execute([$this->name]);
 
-            return ($this->stmtReleaseLock->fetchColumn() == 1);
+            return ((int)$this->stmtReleaseLock->fetchColumn() === 1);
         }
 
         return false;

--- a/src/MySQL.php
+++ b/src/MySQL.php
@@ -75,7 +75,7 @@ class MySQL implements MutexInterface
             $this->stmtGetLock = $pdo->prepare('SELECT GET_LOCK(?, ?)');
         }
 
-        $this->stmtGetLock->execute(array($this->name, $wait));
+        $this->stmtGetLock->execute([$this->name, $wait]);
         $result = $this->stmtGetLock->fetchColumn();
 
         if (is_numeric($result)) {
@@ -104,7 +104,7 @@ class MySQL implements MutexInterface
             }
 
             $this->isLocked = false;
-            $this->stmtReleaseLock->execute(array($this->name));
+            $this->stmtReleaseLock->execute([$this->name]);
 
             return ($this->stmtReleaseLock->fetchColumn() == 1);
         }
@@ -133,20 +133,20 @@ class MySQL implements MutexInterface
             $timeout = filter_var(
                 \Phlib\Config\get($this->dbConfig, 'timeout'),
                 FILTER_VALIDATE_INT,
-                array(
-                    'options' => array(
+                [
+                    'options' => [
                         'default' => 2,
                         'min_range' => 0,
                         'max_range' => 120
-                    )
-                )
+                    ]
+                ]
             );
 
-            $options = array(
+            $options = [
                 \PDO::ATTR_TIMEOUT => $timeout,
                 \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
                 \PDO::ATTR_DEFAULT_FETCH_MODE => \PDO::FETCH_ASSOC
-            );
+            ];
 
             $this->connection = new \PDO(
                 $dsn,

--- a/src/MySQL.php
+++ b/src/MySQL.php
@@ -82,7 +82,7 @@ class MySQL implements MutexInterface
             if ($result == 1) {
                 $this->isLocked = true;
                 return true;
-            } else if ($result == 0) {
+            } elseif ($result == 0) {
                 return false;
             }
         }
@@ -137,15 +137,15 @@ class MySQL implements MutexInterface
                     'options' => [
                         'default' => 2,
                         'min_range' => 0,
-                        'max_range' => 120
-                    ]
+                        'max_range' => 120,
+                    ],
                 ]
             );
 
             $options = [
                 \PDO::ATTR_TIMEOUT => $timeout,
                 \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
-                \PDO::ATTR_DEFAULT_FETCH_MODE => \PDO::FETCH_ASSOC
+                \PDO::ATTR_DEFAULT_FETCH_MODE => \PDO::FETCH_ASSOC,
             ];
 
             $this->connection = new \PDO(

--- a/src/MySQL.php
+++ b/src/MySQL.php
@@ -11,35 +11,17 @@ namespace Phlib\Mutex;
  */
 class MySQL implements MutexInterface
 {
-    /**
-     * @var array
-     */
-    private $dbConfig;
+    private array $dbConfig;
 
-    /**
-     * @var string
-     */
-    private $name;
+    private string $name;
 
-    /**
-     * @var \PDO
-     */
-    private $connection;
+    private \PDO $connection;
 
-    /**
-     * @var \PDOStatement
-     */
-    private $stmtGetLock;
+    private \PDOStatement $stmtGetLock;
 
-    /**
-     * @var \PDOStatement
-     */
-    private $stmtReleaseLock;
+    private \PDOStatement $stmtReleaseLock;
 
-    /**
-     * @var bool
-     */
-    private $isLocked = false;
+    private bool $isLocked = false;
 
     /**
      * @param array $dbConfig {
@@ -65,7 +47,7 @@ class MySQL implements MutexInterface
             return true;
         }
 
-        if (!$this->stmtGetLock instanceof \PDOStatement) {
+        if (!isset($this->stmtGetLock)) {
             $pdo = $this->getConnection();
             $this->stmtGetLock = $pdo->prepare('SELECT GET_LOCK(?, ?)');
         }
@@ -88,7 +70,7 @@ class MySQL implements MutexInterface
     public function unlock(): bool
     {
         if ($this->isLocked) {
-            if (!$this->stmtReleaseLock instanceof \PDOStatement) {
+            if (!isset($this->stmtReleaseLock)) {
                 $pdo = $this->getConnection();
                 $this->stmtReleaseLock = $pdo->prepare('SELECT RELEASE_LOCK(?)');
             }
@@ -110,7 +92,7 @@ class MySQL implements MutexInterface
      */
     protected function getConnection(): \PDO
     {
-        if (!$this->connection instanceof \PDO) {
+        if (!isset($this->connection)) {
             if (!isset($this->dbConfig['host'])) {
                 throw new \InvalidArgumentException('Missing host config param');
             }

--- a/src/MySQL.php
+++ b/src/MySQL.php
@@ -40,9 +40,6 @@ class MySQL implements MutexInterface
     protected $isLocked = false;
 
     /**
-     * Constructor
-     *
-     * @param string $name
      * @param array $dbConfig {
      *     @var string $host     Required.
      *     @var int    $port     Optional. Default 3306.
@@ -51,20 +48,16 @@ class MySQL implements MutexInterface
      *     @var int    $timeout  Optional. Connection timeout in seconds. Default 2.
      * }
      */
-    public function __construct($name, array $dbConfig)
+    public function __construct(string $name, array $dbConfig)
     {
         $this->dbConfig = $dbConfig;
         $this->name = $name;
     }
 
     /**
-     * Lock
-     *
      * @param int $wait Number of seconds to wait for lock
-     * @return boolean
-     * @throws \RuntimeException
      */
-    public function lock($wait = 0)
+    public function lock(int $wait = 0): bool
     {
         if ($this->isLocked) {
             return true;
@@ -90,12 +83,7 @@ class MySQL implements MutexInterface
         throw new \RuntimeException("Failure on mutex '{$this->name}'");
     }
 
-    /**
-     * Unlock
-     *
-     * @return boolean
-     */
-    public function unlock()
+    public function unlock(): bool
     {
         if ($this->isLocked) {
             if (!$this->stmtReleaseLock instanceof \PDOStatement) {
@@ -114,10 +102,8 @@ class MySQL implements MutexInterface
 
     /**
      * Get connection, create if required
-     *
-     * @return \PDO
      */
-    protected function getConnection()
+    protected function getConnection(): \PDO
     {
         if (!$this->connection instanceof \PDO) {
             if (!isset($this->dbConfig['host'])) {

--- a/src/NotFoundException.php
+++ b/src/NotFoundException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Mutex;
 
 /**

--- a/tests/HelperTest.php
+++ b/tests/HelperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Mutex\Test;
 
 use Phlib\Mutex\Helper;
@@ -34,7 +36,7 @@ class HelperTest extends TestCase
 
         $result = Helper::getOrCreate($this->mutex, $getClosure, $createClosure);
 
-        static::assertEquals($expected, $result);
+        static::assertSame($expected, $result);
     }
 
     public function testGetOrCreateGetException(): void
@@ -84,7 +86,7 @@ class HelperTest extends TestCase
 
         $result = Helper::getOrCreate($this->mutex, $getClosure, $createClosure);
 
-        static::assertEquals($expected, $result);
+        static::assertSame($expected, $result);
     }
 
     public function testGetOrCreateGetFailThenException(): void
@@ -148,7 +150,7 @@ class HelperTest extends TestCase
 
         $result = Helper::getOrCreate($this->mutex, $getClosure, $createClosure);
 
-        static::assertEquals($expected, $result);
+        static::assertSame($expected, $result);
     }
 
     public function testGetOrCreateGetFailThenCreateWait(): void
@@ -184,7 +186,7 @@ class HelperTest extends TestCase
 
         $result = Helper::getOrCreate($this->mutex, $getClosure, $createClosure, $wait);
 
-        static::assertEquals($expected, $result);
+        static::assertSame($expected, $result);
     }
 
     public function testGetOrCreateGetFailThenLocked(): void

--- a/tests/HelperTest.php
+++ b/tests/HelperTest.php
@@ -15,20 +15,20 @@ class HelperTest extends TestCase
      */
     protected $mutex;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         // Mock Mutex
         $this->mutex = $this->createMock(MutexInterface::class);
     }
 
-    public function testGetOrCreateGetValid()
+    public function testGetOrCreateGetValid(): void
     {
         $expected = 'valid';
 
-        $getClosure = function () use ($expected) {
+        $getClosure = function () use ($expected): string {
             return $expected;
         };
-        $createClosure = function () {
+        $createClosure = function (): void {
             static::fail('Create Closure was not expected to be called');
         };
 
@@ -37,22 +37,22 @@ class HelperTest extends TestCase
         static::assertEquals($expected, $result);
     }
 
-    public function testGetOrCreateGetException()
+    public function testGetOrCreateGetException(): void
     {
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('Get exception');
 
-        $getClosure = function () {
+        $getClosure = function (): void {
             throw new \Exception('Get exception');
         };
-        $createClosure = function () {
+        $createClosure = function (): void {
             static::fail('Create Closure was not expected to be called');
         };
 
         Helper::getOrCreate($this->mutex, $getClosure, $createClosure);
     }
 
-    public function testGetOrCreateGetFailThenValid()
+    public function testGetOrCreateGetFailThenValid(): void
     {
         $expected = 'valid';
 
@@ -68,7 +68,7 @@ class HelperTest extends TestCase
                     return null;
             }
         };
-        $createClosure = function () {
+        $createClosure = function (): void {
             static::fail('Create Closure was not expected to be called');
         };
 
@@ -87,7 +87,7 @@ class HelperTest extends TestCase
         static::assertEquals($expected, $result);
     }
 
-    public function testGetOrCreateGetFailThenException()
+    public function testGetOrCreateGetFailThenException(): void
     {
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('Get exception');
@@ -105,14 +105,18 @@ class HelperTest extends TestCase
                     break;
             }
         };
-        $createClosure = function () {
+        $createClosure = function (): void {
             static::fail('Create Closure was not expected to be called');
         };
+
+        $this->mutex->expects(static::once())
+            ->method('lock')
+            ->willReturn(true);
 
         Helper::getOrCreate($this->mutex, $getClosure, $createClosure);
     }
 
-    public function testGetOrCreateGetFailThenCreate()
+    public function testGetOrCreateGetFailThenCreate(): void
     {
         $expected = 'valid';
 
@@ -128,7 +132,7 @@ class HelperTest extends TestCase
                     break;
             }
         };
-        $createClosure = function () use ($expected) {
+        $createClosure = function () use ($expected): string {
             return $expected;
         };
 
@@ -147,7 +151,7 @@ class HelperTest extends TestCase
         static::assertEquals($expected, $result);
     }
 
-    public function testGetOrCreateGetFailThenCreateWait()
+    public function testGetOrCreateGetFailThenCreateWait(): void
     {
         $expected = 'valid';
 
@@ -163,7 +167,7 @@ class HelperTest extends TestCase
                     break;
             }
         };
-        $createClosure = function () use ($expected) {
+        $createClosure = function () use ($expected): string {
             return $expected;
         };
 
@@ -183,7 +187,7 @@ class HelperTest extends TestCase
         static::assertEquals($expected, $result);
     }
 
-    public function testGetOrCreateGetFailThenLocked()
+    public function testGetOrCreateGetFailThenLocked(): void
     {
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Unable to acquire lock on mutex');
@@ -200,7 +204,7 @@ class HelperTest extends TestCase
                     break;
             }
         };
-        $createClosure = function () {
+        $createClosure = function (): void {
             static::fail('Create Closure was not expected to be called');
         };
 
@@ -213,7 +217,7 @@ class HelperTest extends TestCase
         Helper::getOrCreate($this->mutex, $getClosure, $createClosure);
     }
 
-    public function testGetOrCreateGetFailThenCreateUnlockFail()
+    public function testGetOrCreateGetFailThenCreateUnlockFail(): void
     {
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Unable to release lock on mutex');
@@ -232,7 +236,7 @@ class HelperTest extends TestCase
                     break;
             }
         };
-        $createClosure = function () use ($expected) {
+        $createClosure = function () use ($expected): string {
             return $expected;
         };
 
@@ -249,7 +253,7 @@ class HelperTest extends TestCase
         Helper::getOrCreate($this->mutex, $getClosure, $createClosure);
     }
 
-    public function testGetOrCreateGetFailThenCreateException()
+    public function testGetOrCreateGetFailThenCreateException(): void
     {
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('Create exception');
@@ -266,14 +270,18 @@ class HelperTest extends TestCase
                     break;
             }
         };
-        $createClosure = function () {
+        $createClosure = function (): void {
             throw new \Exception('Create exception');
         };
+
+        $this->mutex->expects(static::once())
+            ->method('lock')
+            ->willReturn(true);
 
         Helper::getOrCreate($this->mutex, $getClosure, $createClosure);
     }
 
-    public function testGetOrCreateGetFailThenCreateNotFoundException()
+    public function testGetOrCreateGetFailThenCreateNotFoundException(): void
     {
         $this->expectException(NotFoundException::class);
         $this->expectExceptionMessage('Create not found exception');
@@ -290,9 +298,13 @@ class HelperTest extends TestCase
                     break;
             }
         };
-        $createClosure = function () {
+        $createClosure = function (): void {
             throw new NotFoundException('Create not found exception');
         };
+
+        $this->mutex->expects(static::once())
+            ->method('lock')
+            ->willReturn(true);
 
         Helper::getOrCreate($this->mutex, $getClosure, $createClosure);
     }

--- a/tests/HelperTest.php
+++ b/tests/HelperTest.php
@@ -74,12 +74,12 @@ class HelperTest extends TestCase
             static::fail('Create Closure was not expected to be called');
         };
 
-        $this->mutex->expects(static::at(0))
+        $this->mutex->expects(static::once())
             ->method('lock')
             ->with(0) // Default value
             ->willReturn(true)
         ;
-        $this->mutex->expects(static::at(1))
+        $this->mutex->expects(static::once())
             ->method('unlock')
             ->willReturn(true)
         ;
@@ -138,12 +138,12 @@ class HelperTest extends TestCase
             return $expected;
         };
 
-        $this->mutex->expects(static::at(0))
+        $this->mutex->expects(static::once())
             ->method('lock')
             ->with(0) // Default value
             ->willReturn(true)
         ;
-        $this->mutex->expects(static::at(1))
+        $this->mutex->expects(static::once())
             ->method('unlock')
             ->willReturn(true)
         ;
@@ -174,12 +174,12 @@ class HelperTest extends TestCase
         };
 
         $wait = 10;
-        $this->mutex->expects(static::at(0))
+        $this->mutex->expects(static::once())
             ->method('lock')
             ->with($wait)
             ->willReturn(true)
         ;
-        $this->mutex->expects(static::at(1))
+        $this->mutex->expects(static::once())
             ->method('unlock')
             ->willReturn(true)
         ;
@@ -210,7 +210,7 @@ class HelperTest extends TestCase
             static::fail('Create Closure was not expected to be called');
         };
 
-        $this->mutex->expects(static::at(0))
+        $this->mutex->expects(static::once())
             ->method('lock')
             ->with(0) // Default value
             ->willReturn(false)
@@ -242,12 +242,12 @@ class HelperTest extends TestCase
             return $expected;
         };
 
-        $this->mutex->expects(static::at(0))
+        $this->mutex->expects(static::once())
             ->method('lock')
             ->with(0) // Default value
             ->willReturn(true)
         ;
-        $this->mutex->expects(static::at(1))
+        $this->mutex->expects(static::once())
             ->method('unlock')
             ->willReturn(false)
         ;

--- a/tests/HelperTest.php
+++ b/tests/HelperTest.php
@@ -15,7 +15,7 @@ class HelperTest extends TestCase
     /**
      * @var MutexInterface|MockObject
      */
-    private $mutex;
+    private MockObject $mutex;
 
     protected function setUp(): void
     {

--- a/tests/HelperTest.php
+++ b/tests/HelperTest.php
@@ -25,10 +25,10 @@ class HelperTest extends TestCase
     {
         $expected = 'valid';
 
-        $getClosure = function() use ($expected) {
+        $getClosure = function () use ($expected) {
             return $expected;
         };
-        $createClosure = function() {
+        $createClosure = function () {
             static::fail('Create Closure was not expected to be called');
         };
 
@@ -42,10 +42,10 @@ class HelperTest extends TestCase
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('Get exception');
 
-        $getClosure = function() {
+        $getClosure = function () {
             throw new \Exception('Get exception');
         };
-        $createClosure = function() {
+        $createClosure = function () {
             static::fail('Create Closure was not expected to be called');
         };
 
@@ -57,18 +57,18 @@ class HelperTest extends TestCase
         $expected = 'valid';
 
         $count = 0;
-        $getClosure = function() use ($expected, &$count) {
+        $getClosure = function () use ($expected, &$count) {
             switch (++$count) {
-                case 1 :
+                case 1:
                     throw new NotFoundException('Value not found');
-                case 2 :
+                case 2:
                     return $expected;
-                default :
+                default:
                     static::fail('Get Closure was not expected to be called more than twice');
                     return null;
             }
         };
-        $createClosure = function() {
+        $createClosure = function () {
             static::fail('Create Closure was not expected to be called');
         };
 
@@ -93,19 +93,19 @@ class HelperTest extends TestCase
         $this->expectExceptionMessage('Get exception');
 
         $count = 0;
-        $getClosure = function() use (&$count) {
+        $getClosure = function () use (&$count) {
             switch (++$count) {
-                case 1 :
+                case 1:
                     throw new NotFoundException('Value not found');
-                case 2 :
+                case 2:
                     throw new \Exception('Get exception');
-                default :
+                default:
                     static::fail('Get Closure was not expected to be called more than twice');
                     return null;
                     break;
             }
         };
-        $createClosure = function() {
+        $createClosure = function () {
             static::fail('Create Closure was not expected to be called');
         };
 
@@ -117,19 +117,18 @@ class HelperTest extends TestCase
         $expected = 'valid';
 
         $count = 0;
-        $getClosure = function() use (&$count) {
+        $getClosure = function () use (&$count) {
             switch (++$count) {
-                case 1 :
-                    // no break
-                case 2 :
+                case 1:
+                case 2:
                     throw new NotFoundException('Value not found');
-                default :
+                default:
                     static::fail('Get Closure was not expected to be called more than twice');
                     return null;
                     break;
             }
         };
-        $createClosure = function() use ($expected) {
+        $createClosure = function () use ($expected) {
             return $expected;
         };
 
@@ -153,19 +152,18 @@ class HelperTest extends TestCase
         $expected = 'valid';
 
         $count = 0;
-        $getClosure = function() use (&$count) {
+        $getClosure = function () use (&$count) {
             switch (++$count) {
-                case 1 :
-                    // no break
-                case 2 :
+                case 1:
+                case 2:
                     throw new NotFoundException('Value not found');
-                default :
+                default:
                     static::fail('Get Closure was not expected to be called more than twice');
                     return null;
                     break;
             }
         };
-        $createClosure = function() use ($expected) {
+        $createClosure = function () use ($expected) {
             return $expected;
         };
 
@@ -191,19 +189,18 @@ class HelperTest extends TestCase
         $this->expectExceptionMessage('Unable to acquire lock on mutex');
 
         $count = 0;
-        $getClosure = function() use (&$count) {
+        $getClosure = function () use (&$count) {
             switch (++$count) {
-                case 1 :
-                    // no break
-                case 2 :
+                case 1:
+                case 2:
                     throw new NotFoundException('Value not found');
-                default :
+                default:
                     static::fail('Get Closure was not expected to be called more than twice');
                     return null;
                     break;
             }
         };
-        $createClosure = function() {
+        $createClosure = function () {
             static::fail('Create Closure was not expected to be called');
         };
 
@@ -224,19 +221,18 @@ class HelperTest extends TestCase
         $expected = 'valid';
 
         $count = 0;
-        $getClosure = function() use (&$count) {
+        $getClosure = function () use (&$count) {
             switch (++$count) {
-                case 1 :
-                    // no break
-                case 2 :
+                case 1:
+                case 2:
                     throw new NotFoundException('Value not found');
-                default :
+                default:
                     static::fail('Get Closure was not expected to be called more than twice');
                     return null;
                     break;
             }
         };
-        $createClosure = function() use ($expected) {
+        $createClosure = function () use ($expected) {
             return $expected;
         };
 
@@ -259,19 +255,18 @@ class HelperTest extends TestCase
         $this->expectExceptionMessage('Create exception');
 
         $count = 0;
-        $getClosure = function() use (&$count) {
+        $getClosure = function () use (&$count) {
             switch (++$count) {
-                case 1 :
-                    // no break
-                case 2 :
+                case 1:
+                case 2:
                     throw new NotFoundException('Value not found');
-                default :
+                default:
                     static::fail('Get Closure was not expected to be called more than twice');
                     return null;
                     break;
             }
         };
-        $createClosure = function() {
+        $createClosure = function () {
             throw new \Exception('Create exception');
         };
 
@@ -284,19 +279,18 @@ class HelperTest extends TestCase
         $this->expectExceptionMessage('Create not found exception');
 
         $count = 0;
-        $getClosure = function() use (&$count) {
+        $getClosure = function () use (&$count) {
             switch (++$count) {
-                case 1 :
-                    // no break
-                case 2 :
+                case 1:
+                case 2:
                     throw new NotFoundException('Value not found');
-                default :
+                default:
                     static::fail('Get Closure was not expected to be called more than twice');
                     return null;
                     break;
             }
         };
-        $createClosure = function() {
+        $createClosure = function () {
             throw new NotFoundException('Create not found exception');
         };
 

--- a/tests/HelperTest.php
+++ b/tests/HelperTest.php
@@ -15,7 +15,7 @@ class HelperTest extends TestCase
     /**
      * @var MutexInterface|MockObject
      */
-    protected $mutex;
+    private $mutex;
 
     protected function setUp(): void
     {

--- a/tests/HelperTest.php
+++ b/tests/HelperTest.php
@@ -10,8 +10,6 @@ use PHPUnit\Framework\TestCase;
 
 class HelperTest extends TestCase
 {
-    const LOCK_NAME = 'dummyLock';
-
     /**
      * @var MutexInterface|MockObject
      */

--- a/tests/Integration/MySQLTest.php
+++ b/tests/Integration/MySQLTest.php
@@ -12,10 +12,7 @@ use PHPUnit\Framework\TestCase;
  */
 class MySQLTest extends TestCase
 {
-    /**
-     * @var array
-     */
-    private $dbConfig;
+    private array $dbConfig;
 
     protected function setUp(): void
     {

--- a/tests/Integration/MySQLTest.php
+++ b/tests/Integration/MySQLTest.php
@@ -17,7 +17,7 @@ class MySQLTest extends TestCase
      */
     private $dbConfig;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         if ((bool)getenv('INTEGRATION_ENABLED') !== true) {
             static::markTestSkipped();
@@ -34,7 +34,7 @@ class MySQLTest extends TestCase
         ];
     }
 
-    public function testLock()
+    public function testLock(): void
     {
         $name = sha1(uniqid());
 
@@ -47,7 +47,7 @@ class MySQLTest extends TestCase
         static::assertTrue($unlockResult);
     }
 
-    public function testLockRepeat()
+    public function testLockRepeat(): void
     {
         $name = sha1(uniqid());
 
@@ -64,7 +64,7 @@ class MySQLTest extends TestCase
         static::assertTrue($unlockAResult);
     }
 
-    public function testLockBlocked()
+    public function testLockBlocked(): void
     {
         $name = sha1(uniqid());
 
@@ -82,7 +82,7 @@ class MySQLTest extends TestCase
         static::assertTrue($unlockAResult);
     }
 
-    public function testLockTimeout()
+    public function testLockTimeout(): void
     {
         $name = sha1(uniqid());
 
@@ -105,7 +105,7 @@ class MySQLTest extends TestCase
         static::assertTrue($unlockAResult);
     }
 
-    public function testLockError()
+    public function testLockError(): void
     {
         $this->expectException(\PDOException::class);
         $this->expectExceptionMessage('Incorrect user-level lock name');
@@ -119,7 +119,7 @@ class MySQLTest extends TestCase
         static::assertTrue($lockResult);
     }
 
-    public function testUnlockNoLock()
+    public function testUnlockNoLock(): void
     {
         $name = sha1(uniqid());
 

--- a/tests/Integration/MySQLTest.php
+++ b/tests/Integration/MySQLTest.php
@@ -96,7 +96,7 @@ class MySQLTest extends TestCase
         $lockBResult = $mutexB->lock($lockTimeout);
         $endTime = microtime(true);
         static::assertFalse($lockBResult);
-        static::assertEquals($lockTimeout, $endTime - $startTime, '', 0.01);
+        static::assertEqualsWithDelta($lockTimeout, $endTime - $startTime, 0.01);
 
         $unlockAResult = $mutexA->unlock();
         static::assertTrue($unlockAResult);

--- a/tests/MySQLTest.php
+++ b/tests/MySQLTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Mutex\Test;
 
 use Phlib\Mutex\MySQL;

--- a/tests/MySQLTest.php
+++ b/tests/MySQLTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\TestCase;
  */
 class MySQLTest extends TestCase
 {
-    const LOCK_NAME = 'dummyLock';
+    private const LOCK_NAME = 'dummyLock';
 
     /**
      * @var MySQL|MockObject

--- a/tests/MySQLTest.php
+++ b/tests/MySQLTest.php
@@ -20,22 +20,22 @@ class MySQLTest extends TestCase
     /**
      * @var MySQL|MockObject
      */
-    protected $mutex;
+    private $mutex;
 
     /**
      * @var \PDO|MockObject
      */
-    protected $pdo;
+    private $pdo;
 
     /**
      * @var \PDOStatement|MockObject
      */
-    protected $stmtGetLock;
+    private $stmtGetLock;
 
     /**
      * @var \PDOStatement|MockObject
      */
-    protected $stmtReleaseLock;
+    private $stmtReleaseLock;
 
     protected function setUp(): void
     {

--- a/tests/MySQLTest.php
+++ b/tests/MySQLTest.php
@@ -35,7 +35,7 @@ class MySQLTest extends TestCase
      */
     protected $stmtReleaseLock;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         // Mock PDO classes
         $this->pdo = $this->createMock(\PDO::class);
@@ -48,7 +48,7 @@ class MySQLTest extends TestCase
             ->getMock();
     }
 
-    public function testLock()
+    public function testLock(): void
     {
         $this->mutex->expects(static::once())
             ->method('getConnection')
@@ -72,7 +72,7 @@ class MySQLTest extends TestCase
         static::assertTrue($result);
     }
 
-    public function testLockTimeout()
+    public function testLockTimeout(): void
     {
         $lockTimeout = 30;
 
@@ -98,7 +98,7 @@ class MySQLTest extends TestCase
         static::assertTrue($result);
     }
 
-    public function testLockFailed()
+    public function testLockFailed(): void
     {
         $this->mutex->expects(static::once())
             ->method('getConnection')
@@ -118,7 +118,7 @@ class MySQLTest extends TestCase
         static::assertFalse($result);
     }
 
-    public function testLockInvalidResult()
+    public function testLockInvalidResult(): void
     {
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Failure on mutex');
@@ -139,7 +139,7 @@ class MySQLTest extends TestCase
         $this->mutex->lock();
     }
 
-    public function testLockError()
+    public function testLockError(): void
     {
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Failure on mutex');
@@ -156,7 +156,7 @@ class MySQLTest extends TestCase
         $this->mutex->lock();
     }
 
-    public function testLockExisting()
+    public function testLockExisting(): void
     {
         $this->mutex->expects(static::once())
             ->method('getConnection')
@@ -182,7 +182,7 @@ class MySQLTest extends TestCase
         static::assertTrue($result);
     }
 
-    public function testUnlock()
+    public function testUnlock(): void
     {
         $this->mutex->expects(static::exactly(2))
             ->method('getConnection')
@@ -216,7 +216,7 @@ class MySQLTest extends TestCase
         static::assertTrue($result);
     }
 
-    public function testUnlockFailed()
+    public function testUnlockFailed(): void
     {
         $this->mutex->expects(static::exactly(2))
             ->method('getConnection')
@@ -246,7 +246,7 @@ class MySQLTest extends TestCase
         static::assertFalse($result);
     }
 
-    public function testUnlockNoLock()
+    public function testUnlockNoLock(): void
     {
         $this->mutex->expects(static::never())
             ->method('getConnection')

--- a/tests/MySQLTest.php
+++ b/tests/MySQLTest.php
@@ -56,7 +56,7 @@ class MySQLTest extends TestCase
             ->method('getConnection')
             ->willReturn($this->pdo);
 
-        $this->pdo->expects(static::at(0))
+        $this->pdo->expects(static::once())
             ->method('prepare')
             ->willReturn($this->stmtGetLock);
 
@@ -82,7 +82,7 @@ class MySQLTest extends TestCase
             ->method('getConnection')
             ->willReturn($this->pdo);
 
-        $this->pdo->expects(static::at(0))
+        $this->pdo->expects(static::once())
             ->method('prepare')
             ->willReturn($this->stmtGetLock);
 
@@ -106,7 +106,7 @@ class MySQLTest extends TestCase
             ->method('getConnection')
             ->willReturn($this->pdo);
 
-        $this->pdo->expects(static::at(0))
+        $this->pdo->expects(static::once())
             ->method('prepare')
             ->willReturn($this->stmtGetLock);
 
@@ -129,7 +129,7 @@ class MySQLTest extends TestCase
             ->method('getConnection')
             ->willReturn($this->pdo);
 
-        $this->pdo->expects(static::at(0))
+        $this->pdo->expects(static::once())
             ->method('prepare')
             ->willReturn($this->stmtGetLock);
 
@@ -150,7 +150,7 @@ class MySQLTest extends TestCase
             ->method('getConnection')
             ->willReturn($this->pdo);
 
-        $this->pdo->expects(static::at(0))
+        $this->pdo->expects(static::once())
             ->method('prepare')
             ->willReturn($this->stmtGetLock);
 
@@ -164,7 +164,7 @@ class MySQLTest extends TestCase
             ->method('getConnection')
             ->willReturn($this->pdo);
 
-        $this->pdo->expects(static::at(0))
+        $this->pdo->expects(static::once())
             ->method('prepare')
             ->willReturn($this->stmtGetLock);
 
@@ -190,12 +190,12 @@ class MySQLTest extends TestCase
             ->method('getConnection')
             ->willReturn($this->pdo);
 
-        $this->pdo->expects(static::at(0))
+        $this->pdo->expects(static::exactly(2))
             ->method('prepare')
-            ->willReturn($this->stmtGetLock);
-        $this->pdo->expects(static::at(1))
-            ->method('prepare')
-            ->willReturn($this->stmtReleaseLock);
+            ->willReturnOnConsecutiveCalls(
+                $this->stmtGetLock,
+                $this->stmtReleaseLock
+            );
 
         // Valid lock
         $this->stmtGetLock->expects(static::once())
@@ -224,12 +224,12 @@ class MySQLTest extends TestCase
             ->method('getConnection')
             ->willReturn($this->pdo);
 
-        $this->pdo->expects(static::at(0))
+        $this->pdo->expects(static::exactly(2))
             ->method('prepare')
-            ->willReturn($this->stmtGetLock);
-        $this->pdo->expects(static::at(1))
-            ->method('prepare')
-            ->willReturn($this->stmtReleaseLock);
+            ->willReturnOnConsecutiveCalls(
+                $this->stmtGetLock,
+                $this->stmtReleaseLock
+            );
 
         // Valid lock
         $this->stmtGetLock->expects(static::once())

--- a/tests/MySQLTest.php
+++ b/tests/MySQLTest.php
@@ -20,22 +20,22 @@ class MySQLTest extends TestCase
     /**
      * @var MySQL|MockObject
      */
-    private $mutex;
+    private MockObject $mutex;
 
     /**
      * @var \PDO|MockObject
      */
-    private $pdo;
+    private MockObject $pdo;
 
     /**
      * @var \PDOStatement|MockObject
      */
-    private $stmtGetLock;
+    private MockObject $stmtGetLock;
 
     /**
      * @var \PDOStatement|MockObject
      */
-    private $stmtReleaseLock;
+    private MockObject $stmtReleaseLock;
 
     protected function setUp(): void
     {


### PR DESCRIPTION
- Drop support for PHP <= v7.3 ; add support for v8.0 .
- Upgrade PHPUnit to v9 to support PHP v8.
- Follow PSR-12.
- Add type declarations.