### PR TITLE
Use Phlib/Db to handle DB connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Type declarations have been added to all method parameters and return types
   where possible.
 ### Changed
+- **BC break**: Constructor of `MySQL` requires instance of `\Phlib\Db\Adapter`
+  instead of a raw DB config array. *Phlib/Db* is a new package dependency.
+  Implementations can pass their existing DB config to `Adapter`. See *README*.
 - **BC break**: Reduce visibility of internal methods and properties. These
   members are not part of the public API. No impact to standard use of this
   package. If an implementation has a use case which needs to override these

--- a/README.md
+++ b/README.md
@@ -21,11 +21,12 @@ $ composer require phlib/mutex
 ### MySQL
 
 ```php
-$mutex = new \Phlib\Mutex\MySQL('my-lock', [
-    'host'     => '127.0.0.1',
+$adapter = new \Phlib\Db\Adapter([
+    'host' => '127.0.0.1',
     'username' => 'my-user',
     'password' => 'my-pass'
-]);
+]); 
+$mutex = new \Phlib\Mutex\MySQL('my-lock', $adapter);
 if ($mutex->lock()) {
     // Do some data manipulation while locked
     $mutex->unlock();

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
     ],
     "require": {
         "php" : "^7.4 || ^8.0",
-        "phlib/config" : "^2"
+        "phlib/config" : "^2",
+        "phlib/db" : "^2"
     },
     "suggest": {
         "ext-pdo": "Required to use MySQL mutex",


### PR DESCRIPTION
- Remove duplicated logic in this package for creating DB connections, which is the same in *Phlib/Db*.
- Allows better unit testing with injected dependency, rather than having to mock the tested class to override internal methods.